### PR TITLE
Updated Documentation and fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ class MyWelcomeController extends BaseWelcomeController
 By default the `WelcomeNotification` will send a mail. If you wish to customize the mail you can extend `WelcomeNotification` and override the `buildWelcomeNotificationMessage` method.
 
 ```php
+use Illuminate\Notifications\Messages\MailMessage;
+
 class MyCustomWelcomeNotification extends WelcomeNotification
 {
-    public function buildWelcomeNotificationMessage(): Illuminate\Notifications\Messages\MailMessage
+    public function buildWelcomeNotificationMessage(): MailMessage
     {
         return (new MailMessage)
             ->subject('Welcome to my app')

--- a/src/WelcomeNotification.php
+++ b/src/WelcomeNotification.php
@@ -48,7 +48,7 @@ class WelcomeNotification extends Notification
     {
         return (new MailMessage)
             ->subject(Lang::get('Welcome'))
-            ->line(Lang::get('You are receiving this email an account for you was created.'))
+            ->line(Lang::get('You are receiving this email because an account for you was created.'))
             ->action(Lang::get('Set initial password'), $this->showWelcomeFormUrl)
             ->line(Lang::get('This welcome link will expire in :count minutes.', ['count' => $this->validUntil->diffInRealMinutes()]));
     }


### PR DESCRIPTION
Laravel 6.9
PHP 7.3.8

Documentation for **Customizing the notification** gave me this error
Declaration of {my class} must be compatible {spatie welcomenoticfation class}

Adding a namespace seemed to fix it. 

Also fixed a typo i noticed