### PR TITLE
Add missing down method

### DIFF
--- a/database/migrations/add_welcome_valid_until_field_to_users_table.php.stub
+++ b/database/migrations/add_welcome_valid_until_field_to_users_table.php.stub
@@ -12,4 +12,11 @@ class AddWelcomeValidUntilFieldToUsersTable extends Migration
             $table->timestamp('welcome_valid_until')->nullable();
         });
     }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('welcome_valid_until');
+        });
+    }
 }


### PR DESCRIPTION
`AddWelcomeValidUntilFieldToUsersTable` migration is missing the down method. This pull request will add it.