### PR TITLE
Fix password hashing

### DIFF
--- a/src/WelcomeController.php
+++ b/src/WelcomeController.php
@@ -4,6 +4,7 @@ namespace Spatie\WelcomeNotification;
 
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 use Symfony\Component\HttpFoundation\Response;
 
 class WelcomeController
@@ -20,7 +21,7 @@ class WelcomeController
     {
         $request->validate($this->rules());
 
-        $user->password = bcrypt($request->password);
+        $user->password = Hash::make($request->password);
         $user->welcome_valid_until = null;
         $user->save();
 


### PR DESCRIPTION
Not all of us use bcrypt.

Using Hash::make will use the the setting defined in config('hashing.driver'). Which by default is bcrypt.