### PR TITLE
Authorize CarbonImmutable date

### DIFF
--- a/src/WelcomeNotification.php
+++ b/src/WelcomeNotification.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\WelcomeNotification;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -23,7 +23,7 @@ class WelcomeNotification extends Notification
     /** @var \Carbon\Carbon */
     public $validUntil;
 
-    public function __construct(Carbon $validUntil)
+    public function __construct(CarbonInterface $validUntil)
     {
         $this->validUntil = $validUntil;
     }


### PR DESCRIPTION
As we now can define Carbon date objects as immutable by default (https://dyrynda.com.au/blog/laravel-immutable-dates), this PR allows us to pass a `CarbonImmutable` or a `Carbon` date to the welcome notification without breaking (it is currently breaking as the notification is waiting for a `Carbon` date object).