### PR TITLE
Allow models to specify prop used when generating signed url for welcome

### DIFF
--- a/src/ReceivesWelcomeNotification.php
+++ b/src/ReceivesWelcomeNotification.php
@@ -4,8 +4,17 @@ namespace Spatie\WelcomeNotification;
 
 use Carbon\Carbon;
 
+
 trait ReceivesWelcomeNotification
 {
+    public function useWelcomeNotificationKey(): string
+    {
+        return $this->{$this->useWelcomeNotificationKeyName()};
+    }
+    public function useWelcomeNotificationKeyName(): string
+    {
+        return $this->getKeyName();
+    }
     public function sendWelcomeNotification(Carbon $validUntil)
     {
         $this->notify(new WelcomeNotification($validUntil));

--- a/src/ReceivesWelcomeNotification.php
+++ b/src/ReceivesWelcomeNotification.php
@@ -7,11 +7,22 @@ use Carbon\Carbon;
 
 trait ReceivesWelcomeNotification
 {
-    public function useWelcomeNotificationKey(): string
+    /**
+     * Provides the property to be used by WelcomeNotification when generating
+     * the temporary signed route
+     * @return mixed
+     */
+    public function useWelcomeNotificationKey()
     {
         return $this->{$this->useWelcomeNotificationKeyName()};
     }
-    public function useWelcomeNotificationKeyName(): string
+
+    /**
+     * Provides the property key to be used by useWelcomeNotificationKey when
+     * not overridden by the model.
+     * @return string
+     */
+    public function useWelcomeNotificationKeyName()
     {
         return $this->getKeyName();
     }

--- a/src/WelcomeNotification.php
+++ b/src/WelcomeNotification.php
@@ -68,7 +68,7 @@ class WelcomeNotification extends Notification
 
         $this->showWelcomeFormUrl = URL::temporarySignedRoute(
             'welcome',
-            $this->user->welcome_valid_until,
+            $this->validUntil,
             ['user' => $user->useWelcomeNotificationKey()]
         );
     }

--- a/src/WelcomeNotification.php
+++ b/src/WelcomeNotification.php
@@ -58,6 +58,7 @@ class WelcomeNotification extends Notification
         static::$toMailCallback = $callback;
     }
 
+
     protected function initializeNotificationProperties(User $user)
     {
         $this->user = $user;
@@ -67,8 +68,8 @@ class WelcomeNotification extends Notification
 
         $this->showWelcomeFormUrl = URL::temporarySignedRoute(
             'welcome',
-            $this->validUntil,
-            ['user' => $user->id]
+            $this->user->welcome_valid_until,
+            ['user' => $user->useWelcomeNotificationKey()]
         );
     }
 }


### PR DESCRIPTION
Related to comment spatie/laravel-welcome-notification#28 

I took a bit different of a route and added two methods to `ReceivesWelcomeNotification` to allow models to specify the key to use when generating the signed URL. 

I chose this route to provide backwards compatibility to models with a custom routeKey and/or custom route binding parameters as I could foresee potential issues by this package switching over to using routeKeys.

Models can specify the key to use when generating the signed URL by overriding either method `useWelcomeNotificationKey` or `useWelcomeNotificationKeyName` 

`useWelcomeNotificationKey` provides the actual value used by `ReceivesWelcomeNotification`, and by default will use the key/prop name returned by `useWelcomeNotificationKeyName` (by default provides the id via `getKeyName()`)

```php
public function useWelcomeNotificationKey() {
        return $this->getRouteKey();
}
```

or

```php
public function useWelcomeNotificationKeyName() {
     return 'hashed_id';
}
```

