### PR TITLE
feat: extends base controller class

### DIFF
--- a/src/WelcomeController.php
+++ b/src/WelcomeController.php
@@ -2,12 +2,13 @@
 
 namespace Spatie\WelcomeNotification;
 
+use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Symfony\Component\HttpFoundation\Response;
 
-class WelcomeController
+class WelcomeController extends Controller
 {
     public function showWelcomeForm(Request $request, User $user)
     {


### PR DESCRIPTION
Make the WelcomeNotification controller extends the base controller class included with Laravel (App\Http\Controllers\Controller) to have access to features such as the middleware and authorize methods when extending this controller