### PR TITLE
Fix broken readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Send a welcome notification to new users
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-welcome-notification.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-welcome-notification)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/spatie/laravel-welcome-notification/run-tests?label=tests)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/spatie/laravel-welcome-notification/run-tests.yml?label=tests)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-welcome-notification.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-welcome-notification)
 
 Using this package you can send a `WelcomeNotification` to a new user of your app. The notification contains a secure link to a screen where the user can set an initial password.


### PR DESCRIPTION
This PR fixes the tests status badge in the README, which was broken due to a breaking change with shields.io - see [this issue](https://github.com/badges/shields/issues/8671).