### PR TITLE
using diffForHumans instead of diffInRealMinutes in the welcome message

### DIFF
--- a/src/WelcomeNotification.php
+++ b/src/WelcomeNotification.php
@@ -50,7 +50,7 @@ class WelcomeNotification extends Notification
             ->subject(Lang::get('Welcome'))
             ->line(Lang::get('You are receiving this email because an account was created for you.'))
             ->action(Lang::get('Set initial password'), $this->showWelcomeFormUrl)
-            ->line(Lang::get('This welcome link will expire in :count minutes.', ['count' => $this->validUntil->diffForHumans()]));
+            ->line(Lang::get('This welcome link will expire in :count.', ['count' => $this->validUntil->diffForHumans()]));
     }
 
     public static function toMailUsing($callback)

--- a/src/WelcomeNotification.php
+++ b/src/WelcomeNotification.php
@@ -50,7 +50,7 @@ class WelcomeNotification extends Notification
             ->subject(Lang::get('Welcome'))
             ->line(Lang::get('You are receiving this email because an account was created for you.'))
             ->action(Lang::get('Set initial password'), $this->showWelcomeFormUrl)
-            ->line(Lang::get('This welcome link will expire in :count minutes.', ['count' => $this->validUntil->diffInRealMinutes()]));
+            ->line(Lang::get('This welcome link will expire in :count minutes.', ['count' => $this->validUntil->diffForHumans()]));
     }
 
     public static function toMailUsing($callback)


### PR DESCRIPTION
I’ve noticed a small issue regarding the use of diffInRealMinutes in the welcome message.
To improve the user experience, I recommend replacing diffInRealMinutes with diffForHumans, which provides a more readable and accurate representation of the remaining time. 